### PR TITLE
feat(rpm-ostree-notify): show importance of pending upgrades

### DIFF
--- a/rpm-ostree-notify
+++ b/rpm-ostree-notify
@@ -7,19 +7,22 @@
 
 source "$(dirname "${0}")/rpm-ostree-notify.conf"
 
-msg_summary='Security Advisories Available'
-msg_body="Pending rpm-ostree deployment contains security advisories. Consider to \
-reboot the system."
-
 sleep "${START_DELAY}"  # Let rpm-ostree download latest updates
 
 while true; do
-    if rpm-ostree status | grep 'SecAdvisories'; then
+    sec_advisories=$(rpm-ostree status | grep 'SecAdvisories')
+    if [[ ${sec_advisories} ]]; then
         if [[ ${IMMEDIATE_UPGRADE} ]]; then
             rpm-ostree upgrade
+            msg_end='Consider to reboot the system.'
+        else
+            msg_end='Consider to manually upgrade and reboot the system.'
         fi
+        msg_summary='Security Advisories Available'
+        msg_start='Pending rpm-ostree deployment contains security advisories:'
+        adv_list=$(echo "${sec_advisories}" | cut -d':' -f2)
         # Use urgency critical to ensure I won't overlook the notification
-        notify-send --urgency=critical "${msg_summary}" "${msg_body}"
+        notify-send --urgency=critical "${msg_summary}" "${msg_start} ${adv_list}. ${msg_end}"
     fi
     sleep "${FREQUENCY}"
 done


### PR DESCRIPTION
This may help to decide whether an immediate reboot is necessary, or it
can wait for a while.